### PR TITLE
Make all entity keys available as route parameters

### DIFF
--- a/src/ResourceGenerator/RouteBasedResourceStrategy.php
+++ b/src/ResourceGenerator/RouteBasedResourceStrategy.php
@@ -45,6 +45,11 @@ class RouteBasedResourceStrategy implements StrategyInterface
         if (isset($data[$resourceIdentifier])) {
             $routeParams[$routeIdentifier] = $data[$resourceIdentifier];
         }
+        
+        // Inject all entity keys automatically into route parameters
+        foreach($data as $key => $value) {
+            $routeParams[$key] = $value;
+        }
 
         return new HalResource($data, [
             $resourceGenerator->getLinkGenerator()->fromRoute(


### PR DESCRIPTION
If you have more than one place holder in your route, this fix will automatically replace the other place holders, too.

See issue: https://github.com/mezzio/mezzio-hal/issues/14